### PR TITLE
Added configuration for custom archives

### DIFF
--- a/dtd/probedesc.dtd
+++ b/dtd/probedesc.dtd
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!ELEMENT probedesc (name, probeName, probeClass, index?, specific*, uptimefactor?, defaultargs?, ds*, graphs)>
+<!ELEMENT probedesc (name, probeName, probeClass, index?, specific*, uptimefactor?, defaultargs?, ds*, graphs,archive*)>
 <!ATTLIST specific 
 			name CDATA #REQUIRED
 >
 <!ELEMENT specific (#PCDATA)>
 <!ELEMENT ds ((dsName, dsType)?, (oid | (oidhigh, oidlow) | collect | (collecthigh, collectlow) )?, minValue?, maxValue?, defaultValue?)>
+<!ELEMENT archive (consolFun, xff, steps, rows)>
 <!ELEMENT defaultargs (attr)*>
 <!ELEMENT arg EMPTY>
 <!ATTLIST arg
@@ -35,3 +36,7 @@
 <!ELEMENT probeName (#PCDATA)>
 <!ELEMENT snmpRequester (#PCDATA)>
 <!ELEMENT collect (#PCDATA)>
+<!ELEMENT consolFun (#PCDATA)>
+<!ELEMENT xff (#PCDATA)>
+<!ELEMENT steps (#PCDATA)>
+<!ELEMENT rows (#PCDATA)>

--- a/junit/jrds/configuration/TestProbeDescBuilder.java
+++ b/junit/jrds/configuration/TestProbeDescBuilder.java
@@ -14,6 +14,8 @@ import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.rrd4j.ConsolFun;
+import org.rrd4j.core.ArcDef;
 
 public class TestProbeDescBuilder {
     static final private Logger logger = Logger.getLogger(TestProbeDescBuilder.class);
@@ -33,6 +35,28 @@ public class TestProbeDescBuilder {
         ConfigObjectFactory conf = new ConfigObjectFactory(localpm, localpm.extensionClassLoader);
         conf.getNodeMap(ConfigType.PROBEDESC).put("name", Tools.parseRessource("httpxmlprobedesc.xml"));
         Assert.assertNotNull("Probedesc not build", conf.setProbeDescMap().get("name"));
+    }
+
+    @Test
+    public void testCustomArchive() throws Exception {
+        PropertiesManager localpm = Tools.makePm();
+        ConfigObjectFactory conf = new ConfigObjectFactory(localpm, localpm.extensionClassLoader);
+        conf.getNodeMap(ConfigType.PROBEDESC).put("name", Tools.parseRessource("httpxmlprobedesc.xml"));
+        ArcDef[] archives = conf.setProbeDescMap().get("name").getArchives();
+        Assert.assertEquals(archives.length,2);
+
+        ArcDef archive = archives[0];
+        Assert.assertEquals(ConsolFun.AVERAGE,archive.getConsolFun());
+        Assert.assertEquals(0.5,archive.getXff(),0);
+        Assert.assertEquals(2,archive.getSteps());
+        Assert.assertEquals(3000,archive.getRows());
+
+        archive = archives[1];
+        Assert.assertEquals(ConsolFun.MIN,archive.getConsolFun());
+        Assert.assertEquals(0.7,archive.getXff(),0);
+        Assert.assertEquals(10,archive.getSteps());
+        Assert.assertEquals(5000,archive.getRows());
+
     }
 
     @Test

--- a/junit/ressources/httpxmlprobedesc.xml
+++ b/junit/ressources/httpxmlprobedesc.xml
@@ -32,4 +32,18 @@
 	</ds>
 	<graphs>
 	</graphs>
+    <archive>
+        <consolFun>AVERAGE</consolFun>
+        <xff>0.5</xff>
+        <steps>2</steps>
+        <rows>3000</rows>
+    </archive>
+
+    <archive>
+        <consolFun>MIN</consolFun>
+        <xff>0.7</xff>
+        <steps>10</steps>
+        <rows>5000</rows>
+    </archive>
+
 </probedesc>

--- a/src/jrds/Probe.java
+++ b/src/jrds/Probe.java
@@ -50,11 +50,7 @@ import org.w3c.dom.Element;
         )
 public abstract class Probe<KeyType, ValueType> extends StarterNode implements Comparable<Probe<KeyType, ValueType>>  {
 
-    private static final ArcDef[] DEFAULTARC = {
-        new ArcDef(ConsolFun.AVERAGE, 0.5, 1, 12 * 24 * 30 * 3),
-        new ArcDef(ConsolFun.AVERAGE, 0.5, 12, 24 * 365), 
-        new ArcDef(ConsolFun.AVERAGE, 0.5, 288, 365 * 2)
-    };
+
 
     private String name = null;
     protected HostInfo monitoredHost;
@@ -144,7 +140,7 @@ public abstract class Probe<KeyType, ValueType> extends StarterNode implements C
     public RrdDef getRrdDef() {
         RrdDef def = new RrdDef(getRrdName());
         def.setVersion(2);
-        def.addArchive(DEFAULTARC);
+        def.addArchive(pd.getArchives());
         def.addDatasource(getDsDefs());
         def.setStep(getStep());
         return def;

--- a/src/jrds/ProbeDesc.java
+++ b/src/jrds/ProbeDesc.java
@@ -19,7 +19,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import jrds.factories.ArgFactory;
 
 import org.apache.log4j.Logger;
+import org.rrd4j.ConsolFun;
 import org.rrd4j.DsType;
+import org.rrd4j.core.ArcDef;
 import org.rrd4j.core.DsDef;
 import org.snmp4j.smi.OID;
 import org.w3c.dom.Document;
@@ -41,9 +43,17 @@ public class ProbeDesc implements Cloneable {
     static public final double MINDEFAULT = 0;
     static public final double MAXDEFAULT = Double.NaN;
 
+    private static final ArcDef[] DEFAULTARC = {
+            new ArcDef(ConsolFun.AVERAGE, 0.5, 1, 12 * 24 * 30 * 3),
+            new ArcDef(ConsolFun.AVERAGE, 0.5, 12, 24 * 365),
+            new ArcDef(ConsolFun.AVERAGE, 0.5, 288, 365 * 2)
+    };
+
+
     private long heartBeatDefault = 600;
+    private ArcDef[] archives;
     private Map<String, DsDesc> dsMap;
-    private Map<String, String> specific = new HashMap<String, String>();;
+    private Map<String, String> specific = new HashMap<String, String>();
     private String probeName;
     private String name;
     private final Collection<String> graphesList = new ArrayList<String>();
@@ -411,6 +421,21 @@ public class ProbeDesc implements Cloneable {
      */
     public void setHeartBeatDefault(long heartBeatDefault) {
         this.heartBeatDefault = heartBeatDefault;
+    }
+
+    public ArcDef[] getArchives() {
+        if(archives == null)
+            return DEFAULTARC;
+        return archives;
+    }
+
+    public void setArchives(ArcDef[] archives) {
+        if(archives == null || archives.length == 0){
+            this.archives = null;
+        }
+        else {
+            this.archives = archives;
+        }
     }
 
     /**


### PR DESCRIPTION
Added the possibility to add custom archives when creating custom probe descriptions. If this feature is not used archives should be created with default values as before.
