### PR TITLE
Fix typos in MySQL graph description and JrdsJSONWriter

### DIFF
--- a/desc/graph/jdbc/mysqlstatusoperations.xml
+++ b/desc/graph/jdbc/mysqlstatusoperations.xml
@@ -28,7 +28,7 @@
   </add>
   <add>
     <name>insert</name>
-	<rpn>Com_inserts,Com_replace,+</rpn>
+	<rpn>Com_insert,Com_replace,+</rpn>
 	<graphType>stack</graphType>
 	<legend>Insert</legend>
   </add>

--- a/desc/graph/jdbc/mysqlstatusoperations.xml
+++ b/desc/graph/jdbc/mysqlstatusoperations.xml
@@ -15,13 +15,10 @@
     <name>Com_select</name>
   </add>
   <add>
-    <name>Com_inserts</name>
+    <name>Com_insert</name>
   </add>
   <add>
     <name>Com_replace</name>
-  </add>
-  <add>
-    <name>Qcache_hits</name>
   </add>
   <add>
     <name>select</name>

--- a/desc/graph/jdbc/mysqlstatustemptab.xml
+++ b/desc/graph/jdbc/mysqlstatustemptab.xml
@@ -12,7 +12,7 @@
 		<name>Created_tmp_tables</name>
 	</add>
 	<add>
-		<rpn>Created_tmp_disk_tab, Created_tmp_tables, /, 100 *</rpn>
+		<rpn>Created_tmp_disk_tab, Created_tmp_tables, /, 100, *</rpn>
 		<graphType>line</graphType>
 		<legend>Temporary tables %</legend>
 	</add>

--- a/src/jrds/webapp/JrdsJSONWriter.java
+++ b/src/jrds/webapp/JrdsJSONWriter.java
@@ -18,7 +18,7 @@ public class JrdsJSONWriter {
 
     public JrdsJSONWriter(HttpServletResponse response) throws IOException {
         response.setContentType("application/json");
-        response.addDateHeader("Last-Modifed", new Date().getTime());
+        response.addDateHeader("Last-Modified", new Date().getTime());
         ServletOutputStream out = response.getOutputStream();
         w = new OutputStreamWriter(out);
         jw = new JSONWriter(w);


### PR DESCRIPTION
Pull request to fix various typos found.

In JrdsJSONWriter.java:
 - The HTTP header should be "Last-Modified" (instead of Last-Modifed)

In mysqlstatusoperations.xml:
 - The data source "Qcache_hits" was defined twice in the file
 - The data source "Com_inserts" should be "Com_insert" as defined by MySqlStatus and MySqlStatusGeneric probes

In mysqlstatustemptab.xml:
 - Missing a comma in <rpn> statement