### PR TITLE
Fix resize issue when dragging the graph tree

### DIFF
--- a/web/details.html
+++ b/web/details.html
@@ -43,7 +43,6 @@ function(dojo, dom, domconstruct, array, on, parser) {
 			}
 			ulds = dom.byId('datastores');
 			array.forEach(response.datastores, function(ds) {
-				console.log(ds);
 				li = dojo.create("li", null, ulds, 'last');
 				a = dojo.create("a", {href: "popup.html?pid=" + response.pid + "&dsName=" + ds.name}, li);
 				a.innerHTML = ds.name;

--- a/web/index.html
+++ b/web/index.html
@@ -98,7 +98,7 @@ require(amdVector, function(local_dojo, local_dijit, local_dojox) {
 				</form>
 				<img id="foldButton" class="dijitTreeIcon dijitFolderClosed" alt="" src="dojo/resources/blank.gif" onClick="doUnfold();" />
 			</div> <!-- treePane -->
-			<div id="centerPane" data-dojo-type="dijit/layout/ContentPane" region="center">
+			<div id="centerPane" data-dojo-type="dijit/layout/LayoutContainer" region="center">
 				<div data-dojo-type="dijit/layout/ContentPane" id="paramsPane" >
 					<form id="dateForm" name="dateForm" data-dojo-type="jrds/RenderForm" >
 						<div data-dojo-type="dijit/layout/ContentPane" class="formblock" >


### PR DESCRIPTION
Here's a suggered fix for the issue #43.

It appears to be a side effect due to the improper usage of dojo markups.

A ContentPane is expected to be the leaf element according to:

http://dojotoolkit.org/reference-guide/1.10/dijit/layout.html