### PR TITLE
Fix classpath for "tests" task of ant

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -304,7 +304,7 @@
 		<mkdir dir="tmp" />
 		<delete dir="${testdir}" />
 		<mkdir dir="${testdir}/rawtestoutput" />
-		<junit printsummary="yes" showoutput="no" failureproperty="junit.failure">
+		<junit printsummary="yes" showoutput="no" failureproperty="junit.failure" fork="true">
 			<sysproperty key="jrds.testloglevel" value="ERROR" />
 			<formatter type="xml" />
 			<classpath refid="test.classpath" />


### PR DESCRIPTION
Sets "fork" to true to force the tests to be runned in a different JVM with the specified classpath.

Otherwise it will use the same classpath as ant and share its classpath which has its own version of junit.

In my case I have a version of ant which cause a NoSuchMethodException when trying to execute the task.

Searching over the web it seems to be a pretty common issue with ant.