### PR TITLE
Fix dojo error when an empty tree is returned.

### DIFF
--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -269,6 +269,12 @@ define("jrds/jrdsTree",
        ],
        function(declare, dojo, dijit) {
 return declare("jrdsTree", dijit.Tree, {
+	focusNode: function(a) {
+		// avoid error on empty trees
+		if (a.domNode != null) {
+			this.inherited(arguments);
+		}
+	},
 	onLoad: function() {
 		if(queryParams.path != null) {
 			//This operation destroy the array used as an argument


### PR DESCRIPTION
In case of an empty tree, for example a filter that matches nothing, a JS error will happen in dojo where it will try to focus the new (non existing) node.

I tried to enable "showRoot" or disable "autoExpand" without luck, the JS error remains, maybe you'll have another idea.