### PR TITLE
Few suggered tweaks for the UI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
 <link href="dijit/themes/nihilo/nihilo.css" rel="stylesheet" type="text/css" />
 <link href="lib/jrds.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript">
-var dojoConfig = { parseOnLoad:false, isDebug: false, locale:'en-us', async: true }
+var dojoConfig = { parseOnLoad:false, isDebug: false, locale:'en-us', async: false }
 </script>
 <script type="text/javascript" src="dojo/dojo.js" ></script>
 <script type="text/javascript" src="lib/jrds.js"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
 <link href="dijit/themes/nihilo/nihilo.css" rel="stylesheet" type="text/css" />
 <link href="lib/jrds.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript">
-var dojoConfig = { parseOnLoad:false, isDebug: false, locale:'en-us', async: false }
+var dojoConfig = { parseOnLoad:false, isDebug: false, locale:'en-us', async: false, defaultDuration: 50 };
 </script>
 <script type="text/javascript" src="dojo/dojo.js" ></script>
 <script type="text/javascript" src="lib/jrds.js"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -97,7 +97,7 @@ require(amdVector, function(local_dojo, local_dijit, local_dojox) {
       				<input id="host" type="text" name="host" size="24" data-dojo-type="dijit/form/TextBox" trim="true" required="true" />
         			<button type="submit" data-dojo-type="dijit/form/Button">Search</button>
 				</form>
-				<img id="foldButton" class="dijitTreeIcon dijitFolderClosed" alt="" src="dojo/resources/blank.gif" onClick="doUnfold();" />
+				<img id="foldButton" class="dijitTreeIcon dijitFolderClosed" alt="" src="dojo/resources/blank.gif" onClick="toggleFold();">
 			</div> <!-- treePane -->
 			<div id="centerPane" data-dojo-type="dijit/layout/LayoutContainer" region="center">
 				<div data-dojo-type="dijit/layout/ContentPane" id="paramsPane" region="top">

--- a/web/lib/jrds.css
+++ b/web/lib/jrds.css
@@ -94,6 +94,11 @@ body, input, option, select, tab, div, td, a, textarea {
 	vertical-align:middle;
 }
 
+.dijitTreeExpandoLoading {
+	background-image: none !important;
+	display: none !important;
+}
+
 .field {
 	margin: 5px;
 	width: 100px;

--- a/web/lib/jrds.css
+++ b/web/lib/jrds.css
@@ -12,6 +12,11 @@ body, input, option, select, tab, div, td, a, textarea {
 	margin:0;
 	padding:0;
 }
+
+:focus {
+	outline:none;
+}
+
 .linelabel {
 	display:inline-block;
 	padding:0.4em;

--- a/web/lib/jrds.css
+++ b/web/lib/jrds.css
@@ -94,6 +94,12 @@ body, input, option, select, tab, div, td, a, textarea {
 	vertical-align:middle;
 }
 
+#foldButton,
+.dijitTreeExpando,
+.dijitTreeContent {
+	cursor: pointer;
+}
+
 .dijitTreeExpandoLoading {
 	background-image: none !important;
 	display: none !important;

--- a/web/lib/jrds.css
+++ b/web/lib/jrds.css
@@ -101,8 +101,12 @@ body, input, option, select, tab, div, td, a, textarea {
 
 #foldButton,
 .dijitTreeExpando,
-.dijitTreeContent {
+.dijitTreeRow {
 	cursor: pointer;
+}
+
+.dijitTreeContainer {
+	width: 100%;
 }
 
 .dijitTreeExpandoLoading {

--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -852,7 +852,7 @@ function startStandBy(pane) {
 	return standby;
 }
 
-function getTree(isFilters, unfold) {	
+function getTree(isFilters) {
 	var treeStandby = startStandBy('treePane');
 	
 	var foldbutton = dojo.byId('foldButton');
@@ -904,21 +904,24 @@ function getTree(isFilters, unfold) {
 		showRoot: false,
 		onClick: loadTree,
 		persist: false,
-		autoExpand: true == unfold,
+		autoExpand: false,
 		isFilters: isFilters,
 		standby: treeStandby
 	}, treeOneDiv);
 }
 
-function doUnfold() {
-	var foldbutton = dojo.byId('foldButton');
-	dojo.toggleClass(foldbutton, "dijitFolderClosed");
-	dojo.toggleClass(foldbutton, "dijitFolderOpened");
+function toggleFold() {
 	var tree = dijit.byId('treeOne');
-	var unfold = tree.attr('autoExpand');
-	var model = tree.attr('model');
-	var type = model.query.type;
-	getTree(tree.isFilters, true != unfold);
+	var foldbutton = dojo.byId('foldButton');
+	if (dojo.hasClass(foldbutton, 'dijitFolderClosed')) {
+		tree.expandAll();
+		dojo.removeClass(foldbutton, "dijitFolderClosed");
+		dojo.addClass(foldbutton, "dijitFolderOpened");
+	} else {
+		tree.collapseAll();
+		dojo.addClass(foldbutton, "dijitFolderClosed");
+		dojo.removeClass(foldbutton, "dijitFolderOpened");
+	}
 }
 
 function getTreeNodeUp(node) {

--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -840,21 +840,21 @@ function startStandBy(pane) {
 		return null;
 	var standbyName = 'standby.' + pane;
 	var standby = dijit.byId(standbyName);
-	if(standby) {
-		standby.destroyRecursive(false);
-	};
-	standby = new dojox.widget.Standby({
-		target: pane,
-		id: standbyName
-	});
-	document.body.appendChild(standby.domNode);
+	if(!standby) {
+		standby = new dojox.widget.Standby({
+			target: pane,
+			id: standbyName,
+			duration: 0
+		});
+		document.body.appendChild(standby.domNode);
+	}
 	standby.show();
 	return standby;
 }
 
 function getTree(isFilters) {
 	var treeStandby = startStandBy('treePane');
-	
+
 	var foldbutton = dojo.byId('foldButton');
 	var treeType;
 	if(isFilters) {

--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -932,22 +932,7 @@ function toggleFold() {
 	}
 }
 
-function getTreeNodeUp(node) {
-	var nodeInfo = node.item.id;
-	if(nodeInfo instanceof Array) {
-		nodeInfo = nodeInfo[0];
-	}
-	if(node.item.root) {
-		return new Array(nodeInfo);
-	}
-	retValue = getTreeNodeUp(node.getParent());
-	retValue.push(nodeInfo);
-	return retValue;
-}
-
 function loadTree(item,  node){
-	var tree = node.tree;
-
 	if(item.filter) {
 		queryParams.filter = item.filter[0];
 		delete queryParams.host;
@@ -969,7 +954,7 @@ function loadTree(item,  node){
 	else {
 		queryParams.id = item.id[0].replace(/.*\./, "");
 		getGraphList();
-		queryParams.path = getTreeNodeUp(node);		
+		queryParams.path = node.getTreePath().map(function(node) { return node.id instanceof Array ? node.id[0] : node.id; });
 	}
 }
 

--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -279,6 +279,14 @@ return declare("jrdsTree", dijit.Tree, {
 			this.standby.hide();
 		}
 	},
+	_onExpandoClick: function(a) {
+		a = a.node;
+		if (a.deferredExpando != undefined && !a.deferredExpando.isFulfilled()) {
+			return;
+		}
+		this.focusNode(a);
+		a.deferredExpando = a.isExpanded ? this._collapseNode(a) : this._expandNode(a)
+	},
 	getIconClass: function(item, opened){
 		if(item.type == 'filter')
 			return "filterFolder";


### PR DESCRIPTION
- remove UI flickering at load time (which display admin's tab content even if disabled)
- unfold button now also fold and do not re-run the query (no need we have all the tree)
- hides the "root loading" icon (appears because we hide the root) since we have a standBy widget already, fix tree content that moves around because of it
- adds cursor:pointer on clickable element
- remove ugly grey outline and navigating the tree
- reduce time of ALL css effect, when you want to go fast you have to wait after it wheras the UI should be practical
- fix dojo bug when clicking the same node too quickly
- factorize code by reusing dijit's method

Since I do not have IE, I could not validate that there is no issue introduced.
