### PR TITLE
Various fixes around the State URL

### DIFF
--- a/src/jrds/webapp/JSonTree.java
+++ b/src/jrds/webapp/JSonTree.java
@@ -79,7 +79,7 @@ public class JSonTree extends JSonData {
 
     private boolean evaluateTree(ParamsBean params, JrdsJSONWriter w, HostsList root, GraphTree trytree) throws IOException, JSONException {
         for(GraphTree tree: findRoot(Collections.singleton(trytree))) {
-            sub(params, w, tree, "tree", Filter.EVERYTHING, "", tree.hashCode());
+            sub(params, w, tree, "tree", Filter.EVERYTHING, "", tree.getPath().hashCode());
         }
         return true;
     }
@@ -98,7 +98,7 @@ public class JSonTree extends JSonData {
         }
 
         for(GraphTree tree: findRoot(rootToDo)) {
-            sub(params, w, tree, "tree", f, "", tree.hashCode());
+            sub(params, w, tree, "tree", f, "", tree.getPath().hashCode());
         }
         return true;
     }

--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -279,7 +279,12 @@ return declare("jrdsTree", dijit.Tree, {
 		if(queryParams.path != null) {
 			//This operation destroy the array used as an argument
 			//so clone it !
-			this.attr('path', dojo.clone(queryParams.path));
+			var tree = this;
+			this.attr('path', dojo.clone(queryParams.path)).then(function() {
+				if (tree.selectedNode.isExpandable && !tree.selectedNode.isExpanded) {
+					tree._expandNode(tree.selectedNode);
+				}
+			});
 		}
 		if(this.standby != null) {
 			this.standby.hide();


### PR DESCRIPTION
- Rapid expiration of the URL due to the fact that some tree's ID were based on an hashcode of the object itself, not what it represent (thus new graph => new hashCode)
- If state URL targets a folder, automatically open it
- fix issue where state URL would not work from another state URL (=> multiple 'p' parameter => fail)