### PR TITLE
Disable hotkeys for TabContainer.

### DIFF
--- a/web/lib/jrds.js
+++ b/web/lib/jrds.js
@@ -525,6 +525,7 @@ define("jrds/Tabs",
 		  "dijit/layout/TabContainer" ],
 		function(declare, layout) {
 return declare("jrds.Tabs", layout, {
+	_onKeyDown: function() {},
 	postCreate: function() {
 		this.watch("selectedChildWidget", this.transitTab);
 		return this.inherited(arguments);


### PR DESCRIPTION
When you navigate between your browser tabs using shortcut (ex: ctrl+page up) while you have focus on a form input, it will trigger the keyboard shortcut of the TabContainer and switch tab making the user loose its page's state.

Let's disable the hotkeys of the TabContainer all together since this is pretty much useless in this case.