### PR TITLE
Fix history hidden by overflow:hidden

### DIFF
--- a/web/details.html
+++ b/web/details.html
@@ -71,7 +71,7 @@ function(dojo, dom, domconstruct, array, on, parser) {
 
 </script>
 </head>
-<body class="nihilo fillspace">
+<body class="nihilo fillspace show-overflow">
 	<div data-dojo-type="dijit/layout/BorderContainer" gutters="true" class="fillspace">
 		<div data-dojo-type="dijit/layout/ContentPane" region="center">
 			<div data-dojo-type="dijit/TitlePane" title="Probe instance name">

--- a/web/history.html
+++ b/web/history.html
@@ -30,7 +30,7 @@ require(amdVector, function(local_dojo, local_dijit, local_dojox) {
 </script>
 	</head>
 
-	<body bgcolor="#ffffff">
+	<body bgcolor="#ffffff" class="show-overflow">
     <div  data-dojo-type="dijit/layout/ContentPane" id="graphPane">
       <div class='graphblock'>
       

--- a/web/lib/jrds.css
+++ b/web/lib/jrds.css
@@ -1,6 +1,9 @@
 html, body {
 	width:100%; height:100%; margin:0; padding:0; overflow:hidden; 
 }
+
+.show-overflow { overflow: auto; }
+
 /* Define Polices */
 body, input, option, select, tab, div, td, a, textarea, .link a {
 	font-family:'Bitstream Vera Sans', arial, Tahoma, 'Sans serif';

--- a/web/popup.html
+++ b/web/popup.html
@@ -33,7 +33,7 @@ require(amdVector, function(local_dojo, local_dijit, local_dojox) {
 
 	</head>
 
-	<body bgcolor="#ffffff">
+	<body bgcolor="#ffffff" class="show-overflow">
     <div  dojoType="dijit.layout.ContentPane" id="graphPane">
       <div class='graphblock'>      
       </div>


### PR DESCRIPTION
Fix history hidden by overflow:hidden (required by dojo) by overriding it when not necessary (history, details, and popup)