### PR TITLE
Moved  implementation of JrdsLoggerConfiguration methods to inner class.

### DIFF
--- a/jrds-core/src/main/java/jrds/JrdsLoggerConfiguration.java
+++ b/jrds-core/src/main/java/jrds/JrdsLoggerConfiguration.java
@@ -28,7 +28,7 @@ import org.apache.log4j.PatternLayout;
  * <li>Do not define a log file in the property file or PropertiesManager
  * object.
  * </ul>
- * 
+ *
  * @author Fabrice Bacchella
  */
 public class JrdsLoggerConfiguration {
@@ -37,10 +37,73 @@ public class JrdsLoggerConfiguration {
     static public final String DEFAULTLAYOUT = "[%d] %5p %c : %m%n";
     static public Appender jrdsAppender = null;
     // The managed loggers list
-    static public final Set<String> rootLoggers = new HashSet<String>(Arrays.asList(new String[] {"jrds", "org.mortbay.log", "org.apache", "org.eclipse.jetty" }));
+    static public final Set<String> rootLoggers = new HashSet<String>(Arrays.asList(new String[]{"jrds", "org.mortbay.log", "org.apache", "org.eclipse.jetty"}));
     // Used to check if jrds "own" the log configuration
     // null = we don't know yet
     static private Boolean logOwner = null;
+
+    /**
+     * The actual implementation of the logger helper methods is provided by this inner class.
+     * This is done in order to avoid {@link ClassNotFoundException} being thrown in the event
+     * log4j 2 API bridge is used by a calling application instead of the log4j 1.2 implementation.
+     * This works because the inner class is loaded lazily and only if {@link JrdsLoggerConfiguration#logOwner}
+     * is set to true {@code false}.
+     */
+    private static class JrdsLoggerConfigurationWorker {
+
+        private static void initLog4J() throws IOException {
+            if (jrdsAppender == null) {
+                jrdsAppender = new ConsoleAppender(new org.apache.log4j.SimpleLayout(), DEFAULTLOGFILE);
+                jrdsAppender.setName(APPENDERNAME);
+            }
+            // Configure all the manager logger
+            // Default level is debug, not a very good idea
+            for (String loggerName : rootLoggers) {
+                configureLogger(loggerName, Level.ERROR);
+            }
+        }
+
+        private static void configure(PropertiesManager pm) throws IOException {
+            if (pm.logfile != null && !"".equals(pm.logfile)) {
+                jrdsAppender = new DailyRollingFileAppender(new PatternLayout(DEFAULTLAYOUT), pm.logfile, "'.'yyyy-ww");
+                jrdsAppender.setName(APPENDERNAME);
+            }
+            for (String logger : rootLoggers) {
+                configureLogger(logger, pm.loglevel);
+            }
+            // getLogger change the level of new loggers only
+            Logger.getLogger("jrds").setLevel(pm.loglevel);
+
+            for (Map.Entry<Level, List<String>> e : pm.loglevels.entrySet()) {
+                Level l = e.getKey();
+                for (String logName : e.getValue()) {
+                    Logger.getLogger(logName).setLevel(l);
+                }
+            }
+        }
+
+        private static void configureLogger(String logname, Level level) {
+            Logger externallogger = LogManager.getLoggerRepository().exists(logname);
+            // Change level only for new logger
+            if (externallogger == null) {
+                externallogger = Logger.getLogger(logname);
+                externallogger.setLevel(level);
+            }
+
+            // Replace the appender, not optionally add it
+            if (jrdsAppender != null) {
+                Logger logger = Logger.getLogger(logname);
+                Appender oldApp = logger.getAppender(jrdsAppender.getName());
+                if (oldApp != null)
+                    logger.removeAppender(oldApp);
+                logger.addAppender(jrdsAppender);
+                logger.setAdditivity(false);
+            }
+
+            // Keep the new logger name
+            rootLoggers.add(logname);
+        }
+    }
 
     private JrdsLoggerConfiguration() {
 
@@ -58,21 +121,13 @@ public class JrdsLoggerConfiguration {
      * should be used once. It does nothing if it detect that a appender already
      * exist for the logger <code>jrds</code>. The default logger is the system
      * error output and the default level is error.
-     * 
+     *
      * @throws IOException
      */
     static public void initLog4J() throws IOException {
         // Do nothing if jrds is not allowed to setup logs
-        if(!isLogOwner())
-            return;
-        if(jrdsAppender == null) {
-            jrdsAppender = new ConsoleAppender(new org.apache.log4j.SimpleLayout(), DEFAULTLOGFILE);
-            jrdsAppender.setName(APPENDERNAME);
-        }
-        // Configure all the manager logger
-        // Default level is debug, not a very good idea
-        for(String loggerName: rootLoggers) {
-            configureLogger(loggerName, Level.ERROR);
+        if (isLogOwner()) {
+            JrdsLoggerConfigurationWorker.initLog4J();
         }
     }
 
@@ -86,69 +141,33 @@ public class JrdsLoggerConfiguration {
      * <li><code>log.&lt;level&gt;</code>, followed by a comma separated list of
      * logger, to set the level of those logger to <code>level</code></li>
      * </ul>
-     * 
+     *
      * @param pm a configured PropertiesManager object
      * @throws IOException
      */
     static public void configure(PropertiesManager pm) throws IOException {
-        // Do nothing if jrds is not allowed to setup logs
-        if(!isLogOwner())
-            return;
-
-        if(pm.logfile != null && !"".equals(pm.logfile)) {
-            jrdsAppender = new DailyRollingFileAppender(new PatternLayout(DEFAULTLAYOUT), pm.logfile, "'.'yyyy-ww");
-            jrdsAppender.setName(APPENDERNAME);
-        }
-        for(String logger: rootLoggers) {
-            configureLogger(logger, pm.loglevel);
-        }
-        // getLogger change the level of new loggers only
-        Logger.getLogger("jrds").setLevel(pm.loglevel);
-
-        for(Map.Entry<Level, List<String>> e: pm.loglevels.entrySet()) {
-            Level l = e.getKey();
-            for(String logName: e.getValue()) {
-                Logger.getLogger(logName).setLevel(l);
-            }
+        if (isLogOwner()) {
+            JrdsLoggerConfigurationWorker.configure(pm);
         }
     }
 
     /**
      * This method is used to join other logger branch with the jrds' one and
      * use same setting if it's not already defined
-     * 
+     *
      * @param logname the logger name
-     * @param level the desired default level for this logger
+     * @param level   the desired default level for this logger
      */
     static public void configureLogger(String logname, Level level) {
-        // Do nothing if jrds is not allowed to setup logs
-        if(!isLogOwner())
-            return;
-        Logger externallogger = LogManager.getLoggerRepository().exists(logname);
-        // Change level only for new logger
-        if(externallogger == null) {
-            externallogger = Logger.getLogger(logname);
-            externallogger.setLevel(level);
+        if (isLogOwner()) {
+            JrdsLoggerConfigurationWorker.configureLogger(logname, level);
         }
-
-        // Replace the appender, not optionally add it
-        if(jrdsAppender != null) {
-            Logger logger = Logger.getLogger(logname);
-            Appender oldApp = logger.getAppender(jrdsAppender.getName());
-            if(oldApp != null)
-                logger.removeAppender(oldApp);
-            logger.addAppender(jrdsAppender);
-            logger.setAdditivity(false);
-        }
-
-        // Keep the new logger name
-        rootLoggers.add(logname);
     }
 
     static private synchronized boolean isLogOwner() {
         // logOwner == null mean we don't know yet
         // if will be set to false if a logger called jrds already exist
-        if(logOwner == null) {
+        if (logOwner == null) {
             logOwner = LogManager.getLoggerRepository().exists("jrds") == null;
         }
         return logOwner;


### PR DESCRIPTION
This is done in order to avoid {@link ClassNotFoundException} being thrown in the event log4j 2 API bridge is used by a calling application instead of the log4j 1.2 implementation.